### PR TITLE
Fix publish build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN echo CACHEBUST>/dev/null \
     gnupg1 \
     iproute2 \
     ipset \
+    iptables \
     iputils-ping \
     jq \
     kmod \


### PR DESCRIPTION
This should fix the publish build CI. Earlier it was not able to find the `iptables` binary inside `/usr/sbin` or `/sbin` that's why `iptables-wrapper-installer.sh` was throwing the error https://drone-publish.rancher.io/rancher/hyperkube-base/16/1/3.

For: https://github.com/rancher/rancher/issues/35709, continuation of https://github.com/rancher/hyperkube-base/pull/7