### PR TITLE
Add systemd and autoclean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 RUN echo CACHEBUST>/dev/null \
     && apt-get update \
     && apt-get upgrade -y \
+    && apt-get autoclean
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     apt-transport-https \
     arptables \
@@ -57,6 +58,7 @@ RUN echo CACHEBUST>/dev/null \
     nfs-common \
     samba-common \
     socat \
+    systemd \
     udev \
     util-linux \
     xfsprogs \


### PR DESCRIPTION
This will install systemd while building hyperkube-base and will fix the issue https://github.com/rancher/rancher/issues/40508 and autoclean will remove the old repositories that can no longer be downloaded.

![hyperkube-base](https://user-images.githubusercontent.com/32811240/218460228-b217412a-3ef9-4f9f-94a9-ed20f4944ddb.png)

**TODO:**
- [ ] Create a tag `v0.0.16` when it's merged
- [ ] Update and tag hyperkube
- [ ] Update KDM
