### PR TITLE
Use a working IPTWI_VERSION version (v2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BASEIMAGE ?= ubuntu:22.04
 
 CNI_VERSION ?= v1.3.0
 FLANNEL_CNI_VERSION ?= v1.2.0
-IPTWI_VERSION ?= master
+IPTWI_VERSION ?= v2
 
 TEMP_DIR:=$(shell mktemp -d)
 


### PR DESCRIPTION
This PR fixes the current build which fails because it can't find iptables-wrapper script. The reason is that https://github.com/kubernetes-sigs/iptables-wrappers master now includes a [PR](https://github.com/kubernetes-sigs/iptables-wrappers/pull/6) that substitutes the iptables-wrapper bash script by a binary but requires the user to build the source code of that binary. 

My initial tests using that binary show that something is not working properly because it detects nft even though I am using Ubuntu-20 and iptables legacy is the host mode. Note that initially nft rules are clean:

```
azureuser@mbuil-vm1:~$ sudo iptables-nft-save | wc -l
# Warning: iptables-legacy tables present, use iptables-legacy-save to see them
0
azureuser@mbuil-vm1:~$ sudo iptables-legacy-save | wc -l
52
azureuser@mbuil-vm1:~$ sudo iptables --version
iptables v1.8.4 (legacy)
#After a few minutes
azureuser@mbuil-vm1:~$ docker exec kubelet iptables --version
iptables v1.8.7 (nf_tables)
```
Therefore, I suggest using v2 for the time being, which is the version the current code is compatible with. The reasons to use the binary are basically reducing the amount of required packages: `Using a static binary removes the need to include sh in the kube-proxy image. It also drops the dependency on grep and wc. This reduces the CVE surface.`  but as we are using Ubuntu:22 as the base image, so I don't think that will help us much.

Issue: https://github.com/rancher/rancher/issues/42103