### PR TITLE
Set SYSTEMD_IGNORE_CHROOT=yes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
 
 ARG ARCH=amd64
+ENV SYSTEMD_IGNORE_CHROOT=1
 
 COPY scripts/hyperkube /hyperkube
 COPY scripts/iptables-wrapper-installer.sh /usr/sbin/iptables-wrapper-installer.sh


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/41601

As systemd installed in the latest hyperkube-base, when the user is trying to start a systemd service, it's running within a chroot environment, hence the "start" command is being ignored. Refer to the below error:

```
# systemctl start rpc-statd.service
Running in chroot, ignoring command ‘start’
```

This PR adds an env variable SYSTEMD_IGNORE_CHROOT and set it to yes so that it ignores the chroot environment.

