### PR TITLE
Remove all CNI binaries

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
   image: ubuntu:20.04
   commands:
   - apt-get -y update && apt-get -y install make curl tar
-  - make cni-bin/bin && make scripts/iptables-wrapper-installer.sh
+  - make scripts/iptables-wrapper-installer.sh
   when:
     event:
     - push
@@ -71,7 +71,7 @@ steps:
   image: ubuntu:20.04
   commands:
   - apt-get -y update && apt-get -y install make curl tar
-  - make ARCH=arm64 cni-bin/bin && make ARCH=arm64 scripts/iptables-wrapper-installer.sh
+  - make ARCH=arm64 scripts/iptables-wrapper-installer.sh
   when:
     event:
     - push

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-cni-tars/
-cni-bin/
 scripts/iptables-wrapper-installer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,4 @@ RUN echo CACHEBUST>/dev/null \
 
 RUN /usr/sbin/iptables-wrapper-installer.sh
 
-COPY cni-bin/bin /opt/cni/bin
-
 ENTRYPOINT ["/hyperkube"]

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,8 @@ IMAGE ?= docker.io/oats87/hyperkube-base
 TAG ?= v0.0.1
 
 BASEIMAGE ?= ubuntu:22.04
-
-CNI_VERSION ?= v1.3.0
-FLANNEL_CNI_VERSION ?= v1.2.0
 IPTWI_VERSION ?= v2
-
 TEMP_DIR:=$(shell mktemp -d)
-
-CNI_TARBALL=cni-plugins-linux-$(ARCH)-$(CNI_VERSION).tgz
 
 all: all-push
 
@@ -28,26 +22,14 @@ all-push-images: $(addprefix sub-push-image-,$(ALL_ARCH))
 
 all-push: all-push-images push-manifest
 
-cni-tars/$(CNI_TARBALL):
-	mkdir -p cni-tars/
-	cd cni-tars/ && curl -sSLO --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/${CNI_TARBALL}
-
-cni-bin/bin: cni-tars/$(CNI_TARBALL)
-	mkdir -p cni-bin/bin
-	tar -xz -C cni-bin/bin -f "cni-tars/${CNI_TARBALL}"
-	curl -sSL --retry 5 -o cni-bin/bin/flannel https://github.com/flannel-io/cni-plugin/releases/download/${FLANNEL_CNI_VERSION}/flannel-$(ARCH)
-	chmod +x cni-bin/bin/flannel
-
 scripts/iptables-wrapper-installer.sh:
 	mkdir -p scripts/
 	cd scripts/ && curl -sSLO --retry 5 https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/${IPTWI_VERSION}/iptables-wrapper-installer.sh && chmod +x iptables-wrapper-installer.sh
 
 clean:
-	rm -rf cni-tars/
-	rm -rf cni-bin/
 	rm -f scripts/iptables-wrapper-installer.sh
 
-build: clean cni-bin/bin scripts/iptables-wrapper-installer.sh
+build: clean scripts/iptables-wrapper-installer.sh
 	docker build --pull --build-arg ARCH=${ARCH} -t $(IMAGE):$(TAG)-linux-$(ARCH) .
 
 push: build


### PR DESCRIPTION
We don't need the CNI binaries in hyperkube-base because we are already downloading them in rke-tools and also each CNI binary manifest includes a initContainer that provides the required CNI binaries

Tested with:
* weave
* flannel
* calico
* canal

pings between pods work and I can see the correct `/opt/cni/bin`

Issue: https://github.com/rancher/rancher/issues/43199