### PR TITLE
Remove systemd package from hyperkube-base | fix #41601

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ RUN echo CACHEBUST>/dev/null \
     nfs-common \
     samba-common \
     socat \
-    systemd \
     udev \
     util-linux \
     xfsprogs \


### PR DESCRIPTION
### Updates
- Removed `systemd` package from `Dockerfile`

### Context
- https://github.com/rancher/rancher/issues/41601#issuecomment-1840517238

### Relevant Issue
- Partially Reverts https://github.com/rancher/hyperkube-base/pull/11

- Fixes https://github.com/rancher/rancher/issues/41601